### PR TITLE
Bugfix/jsonpayloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,11 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /bin
-COPY /app .
 
 # Install pip requirements
 ADD requirements.txt .
 RUN python -m pip install -r requirements.txt
+
+COPY /app .
 
 ENTRYPOINT python app.py

--- a/app/app.py
+++ b/app/app.py
@@ -40,7 +40,12 @@ def home_post():
     print(f'json {body}')
 
     try:
-        synology_message = json.loads(body)['message']
+        # using str instead of json.loads() because Synology messages can be invalid json
+        # this could be much improved
+        body_cleaned = str(body).split(':')[2].split('"')[1]
+        # strip final newline if there is one
+        body_cleaned = body_cleaned.split("\\r")[0]
+        synology_message = body_cleaned
         print(f'synology_message {synology_message}')
     except:
         return 'body not json', 400

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,2 +1,9 @@
+#!/usr/bin/env bash
+
+if [ "$WEBHOOK_URL" == "" ] ; then 
+  echo "you should set WEBHOOK_URL in your environment or the service will not run"
+  exit 1
+fi
+
 docker build -t addrum/synology-notifications:latest .
 docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  synology-notifications:
+    image: addrum/synology-notifications:latest
+    environment:
+      - WEBHOOK_URL
+    ports:
+      - 8686:8686


### PR DESCRIPTION
I noticed that the very first "real" notification I got did not get sent to Discord. It's malformed json (includes an unescaped newline), so it fails to load.

Example:
```{"phone_number":"9999999999","message":"DSM update is ready to be installed on diskstation^M"}```

We can extract the message from the json and remove the newline instead. I'm still thinking about the right way to make this work but here's where I'm up to.

Also some maintenance around running / containers for development.